### PR TITLE
feat: add HTTPS support to ALB

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Terraform Plan
       id: plan
       if: github.event_name == 'pull_request'
-      run: terraform plan -no-color -input=false
+      run: terraform plan -no-color -input=false -var="certificate_arn=${{ secrets.ACM_CERTIFICATE_ARN }}"
       continue-on-error: true
 
     - name: Comment PR
@@ -71,4 +71,4 @@ jobs:
 
     - name: Terraform Apply
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: terraform apply -auto-approve -input=false
+      run: terraform apply -auto-approve -input=false -var="certificate_arn=${{ secrets.ACM_CERTIFICATE_ARN }}"


### PR DESCRIPTION
- Add HTTPS listener on port 443 with TLS 1.3 policy
- Redirect HTTP (port 80) to HTTPS with 301 status
- Pass ACM certificate ARN from GitHub secrets to Terraform
- Update ECS service dependency to HTTPS listener