### PR TITLE
fix: install curl in Docker image for ECS health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN cargo build --release -p rail-graph-server
 FROM debian:bookworm-slim
 
 # Install runtime dependencies
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
 RUN groupadd -r appuser && useradd -r -g appuser appuser


### PR DESCRIPTION
The ECS task definition health check uses curl to verify the container is healthy, but curl was not installed in the debian:bookworm-slim base image. This caused all health checks to fail and prevented successful deployments.

Added curl to the runtime dependencies alongside ca-certificates.

## Description
<!-- Provide a clear and concise description of your changes -->

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #

## Type of Change
<!-- Check the relevant option(s) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made
<!-- List the key changes in this PR -->
-
-
-

## Testing
<!-- Describe how you tested your changes -->
- [ ] Tested locally with `trunk serve`
- [ ] All tests pass (`cargo test`)
- [ ] Clippy passes with no warnings (`cargo clippy --all-targets -- -D warnings`)
- [ ] Tested with sample project data

## Screenshots/Demo
<!-- If applicable, add screenshots or a screen recording showing the changes -->

## Checklist
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings
- [ ] I have updated documentation if needed
