### PR TITLE
fix: preserve wait times when syncing forward and return routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.12 - 2025-10-29
+
+## Bug Fixes
+- Fixed sync forward and return journey feature overwriting user-configured wait times in return route - wait times are now preserved when syncing routes
+
 # v0.1.11 - 2025-10-29
 
 ## Features

--- a/src/models/line.rs
+++ b/src/models/line.rs
@@ -611,13 +611,13 @@ impl Line {
             return;
         }
 
-        // Build a map of edge_index -> (track_index, origin_platform, destination_platform)
-        // This preserves user-configured tracks and platforms from the existing return route
-        let existing_settings: HashMap<usize, (usize, usize, usize)> = self.return_route
+        // Build a map of edge_index -> (track_index, origin_platform, destination_platform, wait_time)
+        // This preserves user-configured tracks, platforms, and wait times from the existing return route
+        let existing_settings: HashMap<usize, (usize, usize, usize, Duration)> = self.return_route
             .iter()
             .map(|seg| (
                 seg.edge_index,
-                (seg.track_index, seg.origin_platform, seg.destination_platform)
+                (seg.track_index, seg.origin_platform, seg.destination_platform, seg.wait_time)
             ))
             .collect();
 
@@ -625,31 +625,31 @@ impl Line {
         let mut new_return_route = Vec::new();
 
         for (i, forward_seg) in self.forward_route.iter().rev().enumerate() {
-            // Wait times need to be shifted when reversing because they represent wait at destination
-            // For return_route[i], we need the wait time from the previous stop in forward direction
-            let wait_time = if i < self.forward_route.len() - 1 {
-                // Get wait time from forward_route[len - i - 2] (the next segment in forward direction)
-                self.forward_route[self.forward_route.len() - i - 2].wait_time
-            } else {
-                // Last segment in return route corresponds to first stop
-                self.first_stop_wait_time
-            };
-
-            // If we have existing settings for this edge in return route, preserve tracks/platforms
-            if let Some((track_index, origin_platform, destination_platform)) =
+            // If we have existing settings for this edge in return route, preserve tracks/platforms/wait_time
+            if let Some((track_index, origin_platform, destination_platform, wait_time)) =
                 existing_settings.get(&forward_seg.edge_index) {
-                // Preserve user-configured tracks and platforms, sync wait time, clear duration
+                // Preserve user-configured tracks, platforms, and wait time, clear duration
                 new_return_route.push(RouteSegment {
                     edge_index: forward_seg.edge_index,
                     track_index: *track_index,
                     origin_platform: *origin_platform,
                     destination_platform: *destination_platform,
                     duration: None,
-                    wait_time,
+                    wait_time: *wait_time,
                 });
             } else {
                 // This is a new edge not in the return route, use defaults from forward route
                 // but swap platforms for the reverse direction and clear duration
+                // For wait time: need to shift when reversing because they represent wait at destination
+                // For return_route[i], we need the wait time from the previous stop in forward direction
+                let wait_time = if i < self.forward_route.len() - 1 {
+                    // Get wait time from forward_route[len - i - 2] (the next segment in forward direction)
+                    self.forward_route[self.forward_route.len() - i - 2].wait_time
+                } else {
+                    // Last segment in return route corresponds to first stop
+                    self.first_stop_wait_time
+                };
+
                 new_return_route.push(RouteSegment {
                     edge_index: forward_seg.edge_index,
                     track_index: forward_seg.track_index,
@@ -662,10 +662,6 @@ impl Line {
         }
 
         self.return_route = new_return_route;
-
-        // Sync first stop wait time for return route (which is the last stop of forward route)
-        self.return_first_stop_wait_time = self.forward_route.last()
-            .map_or(self.first_stop_wait_time, |seg| seg.wait_time);
     }
 
     #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]


### PR DESCRIPTION
The route sync feature was overwriting user-configured wait times in the return route. Now preserves existing wait times when they exist, only applying default wait time logic for newly added segments.

## Description
<!-- Provide a clear and concise description of your changes -->

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #

## Type of Change
<!-- Check the relevant option(s) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made
<!-- List the key changes in this PR -->
-
-
-

## Testing
<!-- Describe how you tested your changes -->
- [ ] Tested locally with `trunk serve`
- [ ] All tests pass (`cargo test`)
- [ ] Clippy passes with no warnings (`cargo clippy --all-targets -- -D warnings`)
- [ ] Tested with sample project data

## Screenshots/Demo
<!-- If applicable, add screenshots or a screen recording showing the changes -->

## Checklist
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings
- [ ] I have updated documentation if needed
