### PR TITLE
fix: correct travel time calculation in CSV import with Offset format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.14 - 2025-11-02
+
+## Bug Fixes
+- Fixed CSV import with Offset column format incorrectly calculating travel times by including wait time from the previous station - travel times now correctly represent actual time in motion between stations by subtracting wait time from the previous station's offset
+
 # v0.1.13 - 2025-11-01
 
 ## Features


### PR DESCRIPTION
When using the Offset column format, travel time calculation was incorrectly including wait time from the previous station. The offset represents arrival time at each station, so the departure time must be calculated by adding wait time before computing travel duration.

This ensures travel times accurately represent time in motion between stations, excluding wait/dwell times.

## Description
<!-- Provide a clear and concise description of your changes -->

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #

## Type of Change
<!-- Check the relevant option(s) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made
<!-- List the key changes in this PR -->
-
-
-

## Testing
<!-- Describe how you tested your changes -->
- [ ] Tested locally with `trunk serve`
- [ ] All tests pass (`cargo test`)
- [ ] Clippy passes with no warnings (`cargo clippy --all-targets -- -D warnings`)
- [ ] Tested with sample project data

## Screenshots/Demo
<!-- If applicable, add screenshots or a screen recording showing the changes -->

## Checklist
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings
- [ ] I have updated documentation if needed
