### PR TITLE
fix: render all UI elements for last stop in stops list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.16 - 2025-11-04
+
+## Bug Fixes
+- Fixed last stop in line editor stops list not displaying platform picker, wait time field, estimated time, or deletion button - the last stop now correctly renders all UI elements
+
 # v0.1.15 - 2025-11-03
 
 ## Improvements

--- a/src/components/line_editor/stop_row.rs
+++ b/src/components/line_editor/stop_row.rs
@@ -168,6 +168,7 @@ pub fn StopRow(
                 };
 
                 if index < route.len() {
+                    // Regular stop - has an outgoing segment
                     let segment = &route[index];
                     let prev_dest_platform = if index > 0 && index - 1 < route.len() {
                         Some(route[index - 1].destination_platform)
@@ -180,6 +181,22 @@ pub fn StopRow(
                         prev_dest_platform,
                         Some(petgraph::graph::EdgeIndex::new(segment.edge_index)),
                         Some(segment.track_index),
+                        Some(route.len()),
+                    ))
+                } else if is_last && index > 0 && index - 1 < route.len() {
+                    // Last stop - no outgoing segment, use previous segment's destination
+                    let prev_segment = &route[index - 1];
+                    let prev_dest_platform = if index > 1 && index - 2 < route.len() {
+                        Some(route[index - 2].destination_platform)
+                    } else {
+                        None
+                    };
+
+                    Some((
+                        Some(prev_segment.destination_platform),
+                        prev_dest_platform,
+                        None,  // No outgoing edge
+                        None,  // No outgoing track
                         Some(route.len()),
                     ))
                 } else {


### PR DESCRIPTION
The last stop was missing platform picker, wait time field, estimated time, and deletion button because struct_data memo returned None when index >= route.len(). Added handling for the last stop case by pulling data from the previous segment's destination platform.

## Description
<!-- Provide a clear and concise description of your changes -->

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #

## Type of Change
<!-- Check the relevant option(s) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made
<!-- List the key changes in this PR -->
-
-
-

## Testing
<!-- Describe how you tested your changes -->
- [ ] Tested locally with `trunk serve`
- [ ] All tests pass (`cargo test`)
- [ ] Clippy passes with no warnings (`cargo clippy --all-targets -- -D warnings`)
- [ ] Tested with sample project data

## Screenshots/Demo
<!-- If applicable, add screenshots or a screen recording showing the changes -->

## Checklist
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings
- [ ] I have updated documentation if needed
