### PR TITLE
feat: add next-day rollover for departure times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.17 - 2025-11-05
+
+## Features
+- Added automatic next-day rollover for departure times - when "Last Departure Before" is set to a time earlier than "First Departure" (e.g., First: 23:00, Last: 02:00), the system now automatically schedules trains into the next day with a "+1" indicator displayed in the time input field
+
 # v0.1.16 - 2025-11-04
 
 ## Bug Fixes

--- a/src/components/line_editor/_line_editor.scss
+++ b/src/components/line_editor/_line_editor.scss
@@ -221,6 +221,24 @@
             width: 7rem;
             flex-shrink: 0;
         }
+
+        .time-input-wrapper {
+            position: relative;
+            display: inline-block;
+
+            .next-day-indicator {
+                position: absolute;
+                right: 0.5rem;
+                top: 50%;
+                transform: translateY(-50%);
+                color: #888;
+                font-size: 0.7rem;
+                font-weight: 600;
+                pointer-events: none;
+                user-select: none;
+                z-index: 1;
+            }
+        }
     }
 
     .manual-departures-section {

--- a/src/components/line_editor/auto_schedule_form.rs
+++ b/src/components/line_editor/auto_schedule_form.rs
@@ -145,6 +145,9 @@ pub fn AutoScheduleForm(
                             on_update.call(updated_line);
                         }
                     })
+                    show_next_day_indicator=Signal::derive(move || {
+                        edited_line.get().is_some_and(|l| l.last_departure.time() < l.first_departure.time())
+                    })
                 />
             </div>
 
@@ -167,6 +170,9 @@ pub fn AutoScheduleForm(
                             }
                             on_update.call(updated_line);
                         }
+                    })
+                    show_next_day_indicator=Signal::derive(move || {
+                        edited_line.get().is_some_and(|l| l.return_last_departure.time() < l.return_first_departure.time())
                     })
                 />
             </div>

--- a/src/components/time_input.rs
+++ b/src/components/time_input.rs
@@ -11,53 +11,67 @@ pub fn TimeInput(
     value: Signal<NaiveDateTime>,
     default_time: &'static str,
     on_change: Box<dyn Fn(NaiveDateTime) + 'static>,
+    #[prop(optional)] show_next_day_indicator: Option<Signal<bool>>,
 ) -> impl IntoView {
     let input_ref = create_node_ref::<Input>();
     let on_change = Rc::new(on_change);
     let on_change_clone = on_change.clone();
 
     view! {
-        <label>
+        <label class="time-input-label">
             {label}
-            <input
-                type="text"
-                class="time-input"
-                prop:value=move || value.get().format("%H:%M:%S").to_string()
-                placeholder=default_time
-                node_ref=input_ref
-                on:change=move |ev| {
-                    let time_str = event_target_value(&ev);
-                    if let Ok(naive_time) = crate::time::parse_time_hms(&time_str) {
-                        let new_datetime = BASE_DATE.and_time(naive_time);
-                        on_change(new_datetime);
-                    } else {
-                        // Reset to last valid value if parsing fails
-                        if let Some(input_elem) = input_ref.get() {
-                            input_elem.set_value(&value.get_untracked().format("%H:%M:%S").to_string());
+            <div class="time-input-wrapper">
+                <input
+                    type="text"
+                    class="time-input"
+                    prop:value=move || value.get().format("%H:%M:%S").to_string()
+                    placeholder=default_time
+                    node_ref=input_ref
+                    on:change=move |ev| {
+                        let time_str = event_target_value(&ev);
+                        if let Ok(naive_time) = crate::time::parse_time_hms(&time_str) {
+                            let new_datetime = BASE_DATE.and_time(naive_time);
+                            on_change(new_datetime);
+                        } else {
+                            // Reset to last valid value if parsing fails
+                            if let Some(input_elem) = input_ref.get() {
+                                input_elem.set_value(&value.get_untracked().format("%H:%M:%S").to_string());
+                            }
                         }
                     }
-                }
-                on:keydown=move |ev: KeyboardEvent| {
-                    let key = ev.key();
-                    let adjustment = if key == "j" {
-                        Some(Duration::seconds(-30))
-                    } else if key == "l" {
-                        Some(Duration::seconds(30))
+                    on:keydown=move |ev: KeyboardEvent| {
+                        let key = ev.key();
+                        let adjustment = if key == "j" {
+                            Some(Duration::seconds(-30))
+                        } else if key == "l" {
+                            Some(Duration::seconds(30))
+                        } else {
+                            None
+                        };
+
+                        if let Some(delta) = adjustment {
+                            ev.prevent_default();
+                            let current = value.get_untracked();
+                            let new_datetime = current + delta;
+                            if let Some(input_elem) = input_ref.get() {
+                                input_elem.set_value(&new_datetime.format("%H:%M:%S").to_string());
+                            }
+                            on_change_clone(new_datetime);
+                        }
+                    }
+                />
+                {move || {
+                    if let Some(show_indicator) = show_next_day_indicator {
+                        if show_indicator.get() {
+                            Some(view! { <span class="next-day-indicator">"+1"</span> })
+                        } else {
+                            None
+                        }
                     } else {
                         None
-                    };
-
-                    if let Some(delta) = adjustment {
-                        ev.prevent_default();
-                        let current = value.get_untracked();
-                        let new_datetime = current + delta;
-                        if let Some(input_elem) = input_ref.get() {
-                            input_elem.set_value(&new_datetime.format("%H:%M:%S").to_string());
-                        }
-                        on_change_clone(new_datetime);
                     }
-                }
-            />
+                }}
+            </div>
         </label>
     }
 }


### PR DESCRIPTION
When "Last Departure Before" is set to a time earlier than "First Departure" (e.g., First: 23:00, Last: 02:00), the system now automatically schedules trains into the next day. A "+1" indicator appears in the time input field to show when rollover is active.

Changes:
- Added rollover detection logic to journey generation
- Removed day_end constraint that prevented scheduling into next day
- Enhanced TimeInput component with optional next-day indicator
- Added visual "+1" badge positioned inside time input field

## Description
<!-- Provide a clear and concise description of your changes -->

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #

## Type of Change
<!-- Check the relevant option(s) -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made
<!-- List the key changes in this PR -->
-
-
-

## Testing
<!-- Describe how you tested your changes -->
- [ ] Tested locally with `trunk serve`
- [ ] All tests pass (`cargo test`)
- [ ] Clippy passes with no warnings (`cargo clippy --all-targets -- -D warnings`)
- [ ] Tested with sample project data

## Screenshots/Demo
<!-- If applicable, add screenshots or a screen recording showing the changes -->

## Checklist
- [ ] My code follows the project's code style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings
- [ ] I have updated documentation if needed
